### PR TITLE
copy terraform binaries instead of renaming them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Terraform installation errors when temporary directories on are separate filesystems
 
 ## [0.6.2] - 2022-02-08
 ### Fixed

--- a/src/runners/terraform/tfenv.ts
+++ b/src/runners/terraform/tfenv.ts
@@ -124,7 +124,7 @@ async function downloadVersion(
     zip.extractAllTo(tmpDir.path);
 
     await fs.promises.mkdir(path.join(versionsDir, version));
-    await fs.promises.rename(
+    await fs.promises.copyFile(
       path.join(tmpDir.path, tfExecutable),
       path.join(versionsDir, version, tfExecutable),
     );


### PR DESCRIPTION
This should prevent issues with temporary directories on different filesystems