### PR TITLE
Add CW tagresource permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- AWS CloudWatch TagResource permissions to init generators
 
 ## [0.8.2] - 2022-12-05
 ### Added

--- a/src/init/aws_tf_go_lambda/index.ts
+++ b/src/init/aws_tf_go_lambda/index.ts
@@ -338,7 +338,10 @@ data "aws_iam_policy_document" "function_lambda_role_policy" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
+      "logs:ListTagsForResource",
       "logs:PutLogEvents",
+      "logs:TagResource",
+      "logs:UntagResource",
     ]
 
     resources = [

--- a/src/init/aws_tf_node_lambda/index.ts
+++ b/src/init/aws_tf_node_lambda/index.ts
@@ -329,7 +329,10 @@ data "aws_iam_policy_document" "hello_world_lambda_role_policy" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
+      "logs:ListTagsForResource",
       "logs:PutLogEvents",
+      "logs:TagResource",
+      "logs:UntagResource",
     ]
 
     resources = [

--- a/test/deps/aws/main.tf
+++ b/test/deps/aws/main.tf
@@ -27,7 +27,10 @@ data "aws_iam_policy_document" "boundary" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
+      "logs:ListTagsForResource",
       "logs:PutLogEvents",
+      "logs:TagResource",
+      "logs:UntagResource",
     ]
 
     resources = [
@@ -180,6 +183,11 @@ data "aws_iam_policy_document" "policy" {
     actions = [
       "logs:CreateLogGroup",
       "logs:DeleteLogGroup",
+      "logs:ListTagsForResource",
+      "logs:TagResource",
+      "logs:UntagResource",
+
+      # Deprecated
       "logs:ListTagsLogGroup",
       "logs:TagLogGroup",
       "logs:UntagLogGroup",

--- a/test/esbuildfunctions/example.tf/main.tf
+++ b/test/esbuildfunctions/example.tf/main.tf
@@ -56,7 +56,10 @@ data "aws_iam_policy_document" "hello_world_lambda_role_policy" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
+      "logs:ListTagsForResource",
       "logs:PutLogEvents",
+      "logs:TagResource",
+      "logs:UntagResource",
     ]
 
     resources = [


### PR DESCRIPTION
From AWS:
```
We recommend that, for your IAM policies that are used to access the CreateLogGroup API, you add logs:TagResource permission to your IAM policies by January 31, 2023. The new logs:TagResource permission will not be required for existing accounts that previously used CreateLogGroup API with tags.
```